### PR TITLE
Enable guest order creation

### DIFF
--- a/src/main/kotlin/com/meshhdawi/productlib/orders/GuestOrderItemRequest.kt
+++ b/src/main/kotlin/com/meshhdawi/productlib/orders/GuestOrderItemRequest.kt
@@ -1,0 +1,7 @@
+package com.meshhdawi.productlib.orders
+
+data class GuestOrderItemRequest(
+    val productId: Long,
+    val quantity: Int,
+    val notes: String?
+)

--- a/src/main/kotlin/com/meshhdawi/productlib/orders/GuestOrderRequest.kt
+++ b/src/main/kotlin/com/meshhdawi/productlib/orders/GuestOrderRequest.kt
@@ -1,0 +1,15 @@
+package com.meshhdawi.productlib.orders
+
+import java.time.LocalDateTime
+
+data class GuestOrderRequest(
+    val orderType: OrderType,
+    val address: String,
+    val phone: String,
+    val firstName: String,
+    val lastName: String,
+    val orderNotes: String?,
+    val wishedPickupTime: LocalDateTime?,
+    val language: String?,
+    val items: List<GuestOrderItemRequest>
+)

--- a/src/main/kotlin/com/meshhdawi/productlib/orders/OrdersController.kt
+++ b/src/main/kotlin/com/meshhdawi/productlib/orders/OrdersController.kt
@@ -4,6 +4,8 @@ import com.meshhdawi.productlib.context.getUserId
 import com.meshhdawi.productlib.context.getUserRole
 import com.meshhdawi.productlib.users.UserRole
 import com.meshhdawi.productlib.web.security.AuthService
+import com.meshhdawi.productlib.orders.GuestOrderRequest
+import com.meshhdawi.productlib.orders.OrderEntity
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -55,6 +57,12 @@ class OrdersController(
             val createdOrder = orderService.createOrder(orderRequest)
             ResponseEntity.ok(createdOrder)
         }
+
+    @PostMapping("/guest")
+    fun createGuestOrder(@RequestBody orderRequest: GuestOrderRequest): ResponseEntity<OrderEntity> {
+        val createdOrder = orderService.createGuestOrder(orderRequest)
+        return ResponseEntity.ok(createdOrder)
+    }
 
     @PutMapping("/status")
     fun updateOrderStatus(


### PR DESCRIPTION
## Summary
- add data classes for guest ordering
- extend `OrderService` with a `createGuestOrder` method
- expose `/api/orders/guest` endpoint

## Testing
- `./gradlew test` *(fails: Unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_686f8b01fa0883298a6a928f314d8c1f