### PR TITLE
Add guest order retrieval endpoint

### DIFF
--- a/src/main/kotlin/com/meshhdawi/productlib/orders/OrderRepository.kt
+++ b/src/main/kotlin/com/meshhdawi/productlib/orders/OrderRepository.kt
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface OrderRepository : JpaRepository<OrderEntity, Long> {
 
     fun findByCustomerId(customerId: UserEntity): List<OrderEntity>
+
+    fun findByIdAndLastNameAndCustomerIdIsNull(id: Long, lastName: String): OrderEntity?
 }

--- a/src/main/kotlin/com/meshhdawi/productlib/orders/OrderService.kt
+++ b/src/main/kotlin/com/meshhdawi/productlib/orders/OrderService.kt
@@ -150,6 +150,11 @@ class OrderService(
         }
     }
 
+    fun getGuestOrderById(orderId: Long, lastName: String): OrderEntity {
+        return orderRepository.findByIdAndLastNameAndCustomerIdIsNull(orderId, lastName)
+            ?: throw IllegalArgumentException("Guest order not found with ID: $orderId")
+    }
+
     fun updateOrderStatus(orderStatusRequest: OrderStatusRequest): OrderEntity {
         val order = orderRepository.findById(orderStatusRequest.orderId)
             .orElseThrow { IllegalArgumentException("Order not found with ID: ${orderStatusRequest.orderId}") }

--- a/src/main/kotlin/com/meshhdawi/productlib/orders/OrdersController.kt
+++ b/src/main/kotlin/com/meshhdawi/productlib/orders/OrdersController.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -62,6 +63,15 @@ class OrdersController(
     fun createGuestOrder(@RequestBody orderRequest: GuestOrderRequest): ResponseEntity<OrderEntity> {
         val createdOrder = orderService.createGuestOrder(orderRequest)
         return ResponseEntity.ok(createdOrder)
+    }
+
+    @GetMapping("/guest/{id}")
+    fun getGuestOrderById(
+        @PathVariable id: Long,
+        @RequestParam("lastName") lastName: String
+    ): ResponseEntity<OrderEntity> {
+        val order = orderService.getGuestOrderById(id, lastName)
+        return ResponseEntity.ok(order)
     }
 
     @PutMapping("/status")

--- a/src/test/kotlin/com/meshhdawi/productlib/GuestOrderRepositoryTest.kt
+++ b/src/test/kotlin/com/meshhdawi/productlib/GuestOrderRepositoryTest.kt
@@ -1,0 +1,61 @@
+import com.meshhdawi.productlib.orders.OrderEntity
+import com.meshhdawi.productlib.orders.OrderRepository
+import com.meshhdawi.productlib.orders.OrderType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import kotlin.test.assertNotNull
+
+@Testcontainers
+@SpringBootTest
+class GuestOrderRepositoryTest(
+    @Autowired private val orderRepository: OrderRepository
+) {
+
+    companion object {
+        @Container
+        val postgresContainer = PostgreSQLContainer<Nothing>("postgres:15.2").apply {
+            withDatabaseName("testdb")
+            withUsername("test")
+            withPassword("test")
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun registerPgProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgresContainer::getJdbcUrl)
+            registry.add("spring.datasource.username", postgresContainer::getUsername)
+            registry.add("spring.datasource.password", postgresContainer::getPassword)
+        }
+    }
+
+    @BeforeEach
+    fun setUp() {
+        orderRepository.deleteAll()
+    }
+
+    @Test
+    fun `find guest order by id and last name`() {
+        val order = orderRepository.save(
+            OrderEntity(
+                customerId = null,
+                phone = "1234567890",
+                firstName = "Guest",
+                lastName = "Smith",
+                address = "123 Street",
+                wishedPickupTime = null,
+                type = OrderType.PICKUP
+            )
+        )
+
+        val fetched = orderRepository.findByIdAndLastNameAndCustomerIdIsNull(order.id, "Smith")
+
+        assertNotNull(fetched)
+    }
+}


### PR DESCRIPTION
## Summary
- support looking up guest orders by order ID and last name
- expose new endpoint `/api/orders/guest/{id}`
- provide repository method for fetching guest orders
- add regression test for guest order lookup

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686fb0396d4883298e4c55dcfec729ae