### PR TITLE
Add guest order cancellation endpoint

### DIFF
--- a/src/main/kotlin/com/meshhdawi/productlib/orders/OrderService.kt
+++ b/src/main/kotlin/com/meshhdawi/productlib/orders/OrderService.kt
@@ -229,6 +229,19 @@ class OrderService(
         }
     }
 
+    fun cancelGuestOrder(id: Long, lastName: String): OrderEntity {
+        val order = orderRepository.findByIdAndLastNameAndCustomerIdIsNull(id, lastName)
+            ?: throw IllegalArgumentException("Guest order not found with ID: $id")
+        if (order.status == OrderStatus.CANCELLED) {
+            throw IllegalStateException("Order is already cancelled.")
+        }
+        if (!order.status.isCancelable()) {
+            throw IllegalStateException("لا يمكن الغاء الطلب في هذه المرحلة، يرجى التواصل مع المخبز عبر الهاتف.")
+        }
+        order.status = OrderStatus.CANCELLED
+        return orderRepository.save(order)
+    }
+
     private fun OrderStatus.isCancelable(): Boolean = this == OrderStatus.SUBMITTED || this == OrderStatus.APPROVED
 
     private fun OrderEntity.sendOrderConfirmationEmail() {

--- a/src/main/kotlin/com/meshhdawi/productlib/orders/OrdersController.kt
+++ b/src/main/kotlin/com/meshhdawi/productlib/orders/OrdersController.kt
@@ -74,6 +74,15 @@ class OrdersController(
         return ResponseEntity.ok(order)
     }
 
+    @PutMapping("/guest/cancel/{id}")
+    fun cancelGuestOrder(
+        @PathVariable id: Long,
+        @RequestParam("lastName") lastName: String
+    ): ResponseEntity<OrderEntity> {
+        val cancelledOrder = orderService.cancelGuestOrder(id, lastName)
+        return ResponseEntity.ok(cancelledOrder)
+    }
+
     @PutMapping("/status")
     fun updateOrderStatus(
         @RequestBody orderStatusRequest: OrderStatusRequest,


### PR DESCRIPTION
## Summary
- allow guests to cancel orders using id and family name
- expose the cancelGuestOrder API endpoint

## Testing
- `gradle test` *(fails: Plugin [id: 'org.jetbrains.kotlin.jvm', version: '1.9.25'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc46e036c8329b2a6ade3d03e016e