### PR TITLE
Add phone sanitization

### DIFF
--- a/src/main/kotlin/com/meshhdawi/productlib/orders/OrderService.kt
+++ b/src/main/kotlin/com/meshhdawi/productlib/orders/OrderService.kt
@@ -12,6 +12,7 @@ import com.meshhdawi.productlib.products.ProductService
 import com.meshhdawi.productlib.users.UserRepository
 import com.meshhdawi.productlib.users.UserRole
 import com.meshhdawi.productlib.users.UserService
+import com.meshhdawi.productlib.utils.PhoneUtils
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.format.DateTimeFormatter
@@ -60,12 +61,14 @@ class OrderService(
             throw IllegalStateException("Cart cannot be empty.")
         }
 
+        val sanitizedPhone = PhoneUtils.sanitize(orderRequest.phone)
+
         val savedOrder = orderRepository.save(
             OrderEntity(
                 customerId = customer,
                 type = orderRequest.orderType,
                 address = orderRequest.address,
-                phone = orderRequest.phone,
+                phone = sanitizedPhone,
                 firstName = orderRequest.firstName,
                 lastName = orderRequest.lastName,
                 notes = orderRequest.orderNotes,
@@ -110,12 +113,14 @@ class OrderService(
             throw IllegalStateException("Order must contain at least one item.")
         }
 
+        val sanitizedPhone = PhoneUtils.sanitize(orderRequest.phone)
+
         val savedOrder = orderRepository.save(
             OrderEntity(
                 customerId = null,
                 type = orderRequest.orderType,
                 address = orderRequest.address,
-                phone = orderRequest.phone,
+                phone = sanitizedPhone,
                 firstName = orderRequest.firstName,
                 lastName = orderRequest.lastName,
                 notes = orderRequest.orderNotes,

--- a/src/main/kotlin/com/meshhdawi/productlib/users/UserService.kt
+++ b/src/main/kotlin/com/meshhdawi/productlib/users/UserService.kt
@@ -8,6 +8,7 @@ import com.meshhdawi.productlib.messaging.email.EmailService
 import com.meshhdawi.productlib.users.verification.VerificationService
 import com.meshhdawi.productlib.users.verification.VerificationTokenRepository
 import com.meshhdawi.productlib.web.security.JwtUtil
+import com.meshhdawi.productlib.utils.PhoneUtils
 import org.mindrot.jbcrypt.BCrypt
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
@@ -50,7 +51,8 @@ class UserService(
         validateUserUniqueness(email)
         validatePassword(request.password)
 
-        val sanitizedRequest = request.copy(email = email)
+        val sanitizedPhone = PhoneUtils.sanitize(request.phoneNumber)
+        val sanitizedRequest = request.copy(email = email, phoneNumber = sanitizedPhone)
         val savedUser = repository.save(sanitizedRequest.toUserEntity())
         verificationService.createVerificationToken(savedUser)
         return savedUser
@@ -58,11 +60,12 @@ class UserService(
 
     fun updateUser(userUpdateRequest: UserUpdateRequest): UserEntity {
         val user = getUserById(userUpdateRequest.id)
+        val sanitizedPhone = PhoneUtils.sanitize(userUpdateRequest.phoneNumber)
         return repository.save(
             user.copy(
                 firstName = userUpdateRequest.firstName,
                 lastName = userUpdateRequest.lastName,
-                phoneNumber = userUpdateRequest.phoneNumber,
+                phoneNumber = sanitizedPhone,
                 agreeToReceiveMessages = userUpdateRequest.agreeToReceiveMessages
             )
         )

--- a/src/main/kotlin/com/meshhdawi/productlib/utils/PhoneUtils.kt
+++ b/src/main/kotlin/com/meshhdawi/productlib/utils/PhoneUtils.kt
@@ -12,7 +12,7 @@ object PhoneUtils {
     fun sanitize(phone: String): String {
         val cleaned = phone.trim().replace("[^+0-9]".toRegex(), "")
         if (!allowedRegex.matches(cleaned)) {
-            throw IllegalArgumentException("Invalid phone number")
+            throw IllegalArgumentException("Invalid phone number: must contain only digits, may start with an optional '+', and be 1-15 characters long.")
         }
         return cleaned
     }

--- a/src/main/kotlin/com/meshhdawi/productlib/utils/PhoneUtils.kt
+++ b/src/main/kotlin/com/meshhdawi/productlib/utils/PhoneUtils.kt
@@ -1,7 +1,7 @@
 package com.meshhdawi.productlib.utils
 
 object PhoneUtils {
-    private val allowedRegex = Regex("^[+]?[0-9]*$")
+    private val allowedRegex = Regex("^\\+?[0-9]{1,15}$")
 
     /**
      * Remove spaces and punctuation from the given phone number and make sure
@@ -10,13 +10,9 @@ object PhoneUtils {
      * 15 characters as per E.164 standard.
      */
     fun sanitize(phone: String): String {
-        val cleaned = phone.trim()
-            .replace("(\\s|-|\u00A0|\\(|\))".toRegex(), "")
+        val cleaned = phone.trim().replace("[^+0-9]".toRegex(), "")
         if (!allowedRegex.matches(cleaned)) {
             throw IllegalArgumentException("Invalid phone number")
-        }
-        if (cleaned.length > 15) {
-            throw IllegalArgumentException("Phone number too long")
         }
         return cleaned
     }

--- a/src/main/kotlin/com/meshhdawi/productlib/utils/PhoneUtils.kt
+++ b/src/main/kotlin/com/meshhdawi/productlib/utils/PhoneUtils.kt
@@ -1,0 +1,23 @@
+package com.meshhdawi.productlib.utils
+
+object PhoneUtils {
+    private val allowedRegex = Regex("^[+]?[0-9]*$")
+
+    /**
+     * Remove spaces and punctuation from the given phone number and make sure
+     * it contains only digits with an optional leading plus sign. Throws
+     * [IllegalArgumentException] if the resulting phone number is longer than
+     * 15 characters as per E.164 standard.
+     */
+    fun sanitize(phone: String): String {
+        val cleaned = phone.trim()
+            .replace("(\\s|-|\u00A0|\\(|\))".toRegex(), "")
+        if (!allowedRegex.matches(cleaned)) {
+            throw IllegalArgumentException("Invalid phone number")
+        }
+        if (cleaned.length > 15) {
+            throw IllegalArgumentException("Phone number too long")
+        }
+        return cleaned
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize phone numbers to avoid database errors
- enforce sanitization in user and order creation flows

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687ba12fb65c8329b25206da5d34c041